### PR TITLE
大かっこの設定のOn/Offにする設定の追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,12 @@
         "japanese-proofreading.textlint.丸かっこ（）": {
           "type": "boolean",
           "default": true,
-          "description": "有効（半角の括弧を使用していないかチェックします）"
+          "description": "有効（半角の丸かっこを使用していないかチェックします）"
+        },
+        "japanese-proofreading.textlint.大かっこ［］": {
+          "type": "boolean",
+          "default": true,
+          "description": "有効（半角の大かっこを使用していないかチェックします）"
         },
         "japanese-proofreading.textlint.ら抜き言葉": {
           "type": "boolean",


### PR DESCRIPTION
#24 「大かっこの設定をGUIから無効にできない件」の対応を行いました。

設定のjsonに大かっこの設定の項目がなかったので追加しています。
また、「括弧」の漢字表記を設定名とあわせて「かっこ」表記になおしています。

ご確認よろしくお願いします。
